### PR TITLE
added an optional command to install the theme as a git submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ In your Hugo site `themes` directory, run:
 git clone https://github.com/vimux/mainroad
 ```
 
+Or, if you want to track and update the theme, you can add it as a git submodule via the following command:
+
+```bash
+git submodule add https://github.com/vimux/mainroad
+```
+
 Next, open `config.toml` in the base of the Hugo site and ensure the theme option is set to `mainroad`:
 
 ```


### PR DESCRIPTION
Added an optional command to the **readme** file. Users can choose to add the theme as a git **sub module** and update it directly from git. 